### PR TITLE
Invoke Wait-Process after Stop-Process

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -27,7 +27,9 @@ If (-Not (Test-Path $LOGIN_FILE)) {
 function Stop-RiotProcesses {
     # Stop any existing processes.
     Stop-Process -Name 'RiotClientUx' -ErrorAction Ignore
-    Stop-Process -Name 'LeagueClient' -ErrorAction Ignore
+    Stop-Process -Name 'LeagueClient' -ErrorAction Ignore    
+    Wait-Process -Name 'RiotClientUx' -ErrorAction Ignore
+    Wait-Process -Name 'LeagueClient' -ErrorAction Ignore
     Remove-Item $RCS_LOCKFILE -Force -ErrorAction Ignore
     Remove-Item $LCU_LOCKFILE -Force -ErrorAction Ignore
     Start-Sleep 5 # Wait for processes to settle.


### PR DESCRIPTION
I encountered a permission error trying to access a file under `C:\Riot Games` after doing `Stop-Process` and `Start-Sleep 5`. It went away after I added `Wait-Process`.

`-ErrorAction Ignore` is needed here as well as `Wait-Process` throws an exception if it can't find the process.