### PR TITLE
Using UriBuilder for building the RiotRequest URI

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -60,8 +60,10 @@ function Invoke-RiotRequest {
 
             $pass = ConvertTo-SecureString $pass -AsPlainText -Force
             $cred = New-Object -TypeName PSCredential -ArgumentList 'riot', $pass
+            
+            $uri = New-Object System.UriBuilder -argumentlist 'https', '127.0.0.1', $port, $path | % Uri | % AbsoluteUri
 
-            $result = Invoke-RestMethod "https://127.0.0.1:$port$path" `
+            $result = Invoke-RestMethod $uri `
                 -SkipCertificateCheck `
                 -Method $method `
                 -Authentication 'Basic' `

--- a/update.ps1
+++ b/update.ps1
@@ -61,7 +61,7 @@ function Invoke-RiotRequest {
             $pass = ConvertTo-SecureString $pass -AsPlainText -Force
             $cred = New-Object -TypeName PSCredential -ArgumentList 'riot', $pass
             
-            $uri = New-Object System.UriBuilder -argumentlist 'https', '127.0.0.1', $port, $path | % Uri | % AbsoluteUri
+            $uri = New-Object System.UriBuilder -ArgumentList 'https', '127.0.0.1', $port, $path | % Uri | % AbsoluteUri
 
             $result = Invoke-RestMethod $uri `
                 -SkipCertificateCheck `


### PR DESCRIPTION
Because the action was complaining about an invalid URI format. 🤷🏻‍♂️

https://github.com/MingweiSamuel/lcu-schema/runs/5261971227?check_suite_focus=true#step:4:200

Tested with:

```powershell
PS C:\Users\Mikael> $port = 123
PS C:\Users\Mikael> $path = "/swagger/openapi.json"
PS C:\Users\Mikael> $uri = New-Object System.UriBuilder -ArgumentList 'https', '127.0.0.1', $port, $path | % Uri | % AbsoluteUri
PS C:\Users\Mikael> $uri
https://127.0.0.1:123/swagger/openapi.json
```