### PR TITLE
Fix: remove `ConvertFrom-Json` for `/Help`

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -204,7 +204,7 @@ Try {
 
     Write-Host 'Getting LCU spec files.'
     # /Help is missing the `Content-Type: application/json` header when logged-in.
-    Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Full' | ConvertFrom-Json -AsHashTable | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.json"
+    Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Full' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.json"
     Try {
         Invoke-RiotRequest $LCU_LOCKFILE '/swagger/v3/openapi.json' -Attempts 10 | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\openapi.json"
     }


### PR DESCRIPTION
Seems PowerShell had parsed it already.

The action was complaining about an [illegal `@` at the start](https://github.com/MingweiSamuel/lcu-schema/runs/5565441908?check_suite_focus=true#step:4:102), and it was probably caused by the string representation of the PowerShell object.

![image](https://user-images.githubusercontent.com/3706841/158538878-ed81b583-eaba-4abb-9cf8-084f152d6883.png)
