### PR TITLE
Add help formats Brief, Console and Epytext

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -169,6 +169,9 @@ Try {
     # RCS files.
     Write-Host 'Getting RCS spec files.'
     Invoke-RiotRequest $RCS_LOCKFILE '/Help' -Query '?format=Full' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\help.json"
+    Invoke-RiotRequest $RCS_LOCKFILE '/Help' -Query '?format=Brief' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\help.brief.json"
+    Invoke-RiotRequest $RCS_LOCKFILE '/Help' -Query '?format=Console' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\help.console.json"
+    Invoke-RiotRequest $RCS_LOCKFILE '/Help' -Query '?format=Epytext' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\help.epytext.json"
     Invoke-RiotRequest $RCS_LOCKFILE '/swagger/v3/openapi.json'    | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\openapi.json"
     Invoke-RiotRequest $RCS_LOCKFILE '/swagger/v2/swagger.json'    | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$RCS_OUT_DIR\swagger.json"
 
@@ -205,6 +208,9 @@ Try {
     Write-Host 'Getting LCU spec files.'
     # /Help is missing the `Content-Type: application/json` header when logged-in.
     Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Full' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.json"
+    Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Brief' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.brief.json"
+    Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Console' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.console.json"
+    Invoke-RiotRequest $LCU_LOCKFILE '/Help' -Query '?format=Epytext' | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\help.epytext.json"
     Try {
         Invoke-RiotRequest $LCU_LOCKFILE '/swagger/v3/openapi.json' -Attempts 10 | ConvertTo-Json -Depth 100 | Out-File -Encoding UTF8 "$LCU_OUT_DIR\openapi.json"
     }


### PR DESCRIPTION
Brief is using the `application/json` MIME type.

I guess it makes sense to name `Full` `help.json` and `Brief` `help.brief.json`, as `Full` is the "native" one? Though, the description for `Help` is *"With no arguments, returns a list of all available functions and types along with a short description. If a function or type is specified, returns detailed information about it."*.

❔ Does the naming with dot notation make sense?

--- 

Below is an excerpt from `Full` about the `RemotingHelpFormat`.

```json
{
  "description": "Help format for remoting functions and types.",
  "fields": [],
  "name": "RemotingHelpFormat",
  "nameSpace": "",
  "size": 4,
  "tags": [
      "$builtin",
      "help"
  ],
  "values": [
      {
          "description": "Short description format",
          "name": "Brief",
          "value": 4
      },
      {
          "description": "Console-friendly description format",
          "name": "Console",
          "value": 5
      },
      {
          "description": "Python epytext format",
          "name": "Epytext",
          "value": 2
      },
      {
          "description": "Native help format",
          "name": "Full",
          "value": 1
      }
  ]
}
```