### PR TITLE
Use `urls` instead of `url` in Swagger UI

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,6 +39,7 @@ jobs:
         shell: pwsh
 
       - name: Push changes in output folder
+        if: github.ref_name == github.event.repository.default_branch && github.event_name == 'push'
         shell: bash
         run: |
           git -C out add .

--- a/index.html.diff
+++ b/index.html.diff
@@ -7,7 +7,24 @@ index 32169e36..15193a59 100644
        // Begin Swagger UI call region
        const ui = SwaggerUIBundle({
 -        url: "https://petstore.swagger.io/v2/swagger.json",
-+        url: "../lcu/openapi.json",
++        urls: [
++          {
++            name: "LCU (OpenAPI 3.0)",
++            url:"../lcu/openapi.json",
++          },
++          {
++            name: "LCU (Swagger 2.0)",
++            url:"../lcu/swagger.json",
++          },
++          {
++            name: "RCS (OpenAPI 3.0)",
++            url:"../rcs/openapi.json",
++          },
++          {
++            name: "RCS (Swagger 2.0)",
++            url:"../rcs/swagger.json",
++          },
++        ],
          dom_id: '#swagger-ui',
          deepLinking: true,
          presets: [


### PR DESCRIPTION
# Problem
Currently one needs to enter the path for the definition in order to view it. It's not obvious that there's a "swagger" version of the LCU API definition, neither that there are definitions for RCS available.
![image](https://user-images.githubusercontent.com/3706841/159794867-02706d26-c13e-445a-b6b8-d69559d7b9ea.png)

# Solution
By using the `urls` property in Swagger, instead of `url`, it's possible to specify multiple API definitions for Swagger UI to show the user. It also enabled deep linking to a specific API definition.

Below is an example from the [test Swagger UI for Help2Swagger](https://magisteriis.github.io/riot-games-help-to-swagger-dotnet/).
![image](https://user-images.githubusercontent.com/3706841/159795188-b7c5c319-c39b-4de5-a4d4-de75e9cc19e0.png)
